### PR TITLE
Add `RUNTIME DESTINATION` for genieutils.dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ else()
 
     INSTALL(TARGETS ${Genieutils_LIBRARY}
         LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib
         )
 
     install (


### PR DESCRIPTION
On "dll targets", CMake uses the `RUNTIME DESTINATION` rather than the
`LIBRARY DESTINATION`. Not providing it causes an error on Windows, see
eg this build:

https://ci.appveyor.com/project/goto-bus-stop/wololokingdoms/builds/21171540

For context, I'm working on making [WololoKingdoms](https://github.com/AoE2CommunityGitHub/WololoKingdoms/pull/23) runnable on both Linux
and Windows, and upgraded genieutils to your fork as part of the build
updates I was doing. It now fully compiles and runs on Linux, but not on
Windows anymore! (at least not on Appveyor, but I don't have access to any
other Windowses right now lol)

I'm not a CMake expert by any means, but this appears to work, hopefully
it's not doing something super silly.