### PR TITLE
Document build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ because of possible bugs.
 
 ## Features ###
 
- *   reading/writing of empires*.dat and genie*.dat files
+ *   reading/writing of empires\*.dat and genie\*.dat files
  *   reading (and some writing) of drs, slp, blendomatic, and pal files
  *   reading of scn, scx, cpx, bln files
- *   reading/writing of language*.dll files
+ *   reading/writing of language\*.dll files
 
 
 ## Dependencies ##

--- a/README.md
+++ b/README.md
@@ -19,7 +19,37 @@ because of possible bugs.
 ## Dependencies ##
 
  - A modern C++ Compiler (i. e. supports C++17)
+ - [PCRIO](https://github.com/sandsmark/pcrio) - clone this _next to_ the genieutils folder.
 
 This assumes that you do a recursive clone of the repo or remember to update
 the submodules, otherwise you need to install zstr, and winiconv when building
 for Windows.
+
+You can update submodules after cloning the repo or pulling new commits by doing:
+
+```
+git submodule update --init --recursive
+```
+
+## Building ##
+
+The build uses CMake.
+```
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+This creates a `genieutils.dll` or `libgenieutils.so` file.
+
+To create a static library instead, use the `GENIEUTILS_STATIC_BUILD` flag:
+```
+cmake .. -DGENIEUTILS_STATIC_BUILD=YES
+cmake --build .
+```
+
+Optionally, enable link-time optimization:
+```
+cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_IPO=YES
+cmake --build .
+```


### PR DESCRIPTION
I was helping someone who hadn't used CMake before to get this to build, figured the steps I told them could be added to the readme :)

For pcrio, would it make sense to just also add it as a submodule, and just include its pcrio.c like now?