### PR TITLE
Enable compression

### DIFF
--- a/src/file/Compressor.cpp
+++ b/src/file/Compressor.cpp
@@ -116,7 +116,7 @@ void Compressor::startCompression(void)
 {
     try {
         // Important thing here is window_bits = 15
-        bufferedStream_ = std::make_shared<zstr::ostream>(*ostream_, (std::size_t)1 << 20, false, -15);
+        bufferedStream_ = std::make_shared<zstr::ostream>(*ostream_, (std::size_t)1 << 20, Z_DEFAULT_COMPRESSION, -15);
     } catch (const zstr::Exception &exception) {
         bufferedStream_.reset();
         std::cerr << "Zlib compression failed with error code: "


### PR DESCRIPTION
Previously, this would output a few deflate header bytes but not
compress any of the contents.

I'm not sure if this was an intentional change, but some people reported
AoC crashes with the uncompressed data files from the WIP new WololoKingdoms
installer version.